### PR TITLE
Added support for 'findOrFail' and similar methods

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Spatie\BinaryUuid;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+
+class Builder extends EloquentBuilder {
+  /**
+   * Find a model by its primary key.
+   *
+   * @param  mixed  $id
+   * @param  array  $columns
+   * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|null
+   */
+  public function find($id, $columns = ['*'])
+  {
+      if (is_array($id) || $id instanceof Arrayable) {
+          return $this->findMany($id, $columns);
+      }
+
+      return $this->withUuid($id)->first($columns);
+  }
+
+  /**
+   * Find multiple models by their primary keys.
+   *
+   * @param  \Illuminate\Contracts\Support\Arrayable|array  $ids
+   * @param  array  $columns
+   * @return \Illuminate\Database\Eloquent\Collection
+   */
+  public function findMany($ids, $columns = ['*'])
+  {
+      if (empty($ids)) {
+          return $this->model->newCollection();
+      }
+
+      return $this->withUuid($ids)->get($columns);
+  }
+}

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -4,7 +4,6 @@ namespace Spatie\BinaryUuid;
 
 use Ramsey\Uuid\Uuid;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Builder;
 
 trait HasBinaryUuid
 {
@@ -17,24 +16,6 @@ trait HasBinaryUuid
 
             $model->{$model->getKeyName()} = static::encodeUuid(Uuid::uuid1());
         });
-    }
-
-    public static function find($id, $columns = ['*'])
-    {
-        if (\is_array($id) || $id instanceof Arrayable) {
-            return static::findMany($id, $columns);
-        }
-
-        return static::withUuid($id)->first($columns);
-    }
-
-    public static function findMany($ids, $columns = ['*'])
-    {
-        if (empty($ids)) {
-            return static::newModelInstance()->newCollection();
-        }
-
-        return static::withUuid($ids)->get($columns);
     }
 
     public static function scopeWithUuid(Builder $builder, $uuid, $field = null): Builder
@@ -201,6 +182,11 @@ trait HasBinaryUuid
     public function newQueryForRestoration($id)
     {
         return $this->newQueryWithoutScopes()->whereKey(base64_decode($id));
+    }
+
+    public function newEloquentBuilder($query)
+    {
+        return new Builder($query);
     }
 
     public function getRouteKeyName()

--- a/tests/Feature/HasBinaryUuidTest.php
+++ b/tests/Feature/HasBinaryUuidTest.php
@@ -229,4 +229,13 @@ class HasBinaryUuidTest extends TestCase
         $this->assertCount(2, TestModel::find([$model1->uuid_text, $model3->uuid_text,]));
         $this->assertCount(2, TestModel::findMany([$model1->uuid_text, $model3->uuid_text,]));
     }
+
+    /** @test */
+    public function it_finds_or_fails_a_model_from_its_textual_uuid()
+    {
+      $model = TestModel::create();
+
+      $this->assertTrue($model->is(TestModel::findOrFail($model->uuid)));
+      $this->assertTrue($model->is(TestModel::findOrFail($model->uuid_text)));
+    }
 }


### PR DESCRIPTION
`findOrFail`, `firstOrFail`, `firstOrNew`, etc. exists on `Illuminate\Database\Eloquent\Builder` and _not_ `Illuminate\Database\Eloquent\Model`. When those methods are called they were calling the `find` method on the `Builder` class and not the one that's overridden in the model.

This updates the branch so it overwrites the `find` and `findMany` methods that exist in the `Builder` instead of the `Model`.